### PR TITLE
mark anomalous metrics as such

### DIFF
--- a/analyze/threesigma.go
+++ b/analyze/threesigma.go
@@ -46,6 +46,7 @@ func (t *ThreeSigma) Run() {
 				MetricName: fmt.Sprintf("anode.threesig.%s.anomalous", d.MetricName),
 				Timestamp:  d.Timestamp,
 				Value:      ma,
+				IsAnamoly:  true,
 			}
 		}
 
@@ -54,6 +55,7 @@ func (t *ThreeSigma) Run() {
 			MetricName: fmt.Sprintf("anode.threesig.%s.mean", d.MetricName),
 			Timestamp:  d.Timestamp,
 			Value:      mean,
+			IsAnamoly:  false,
 		}
 
 		// Output mean +/- 3 standard deviations.
@@ -61,11 +63,13 @@ func (t *ThreeSigma) Run() {
 			MetricName: fmt.Sprintf("anode.threesig.%s.upper", d.MetricName),
 			Timestamp:  d.Timestamp,
 			Value:      t.stats.Mean() + 3*stddev,
+			IsAnamoly:  false,
 		}
 		t.output <- data.Datapoint{
 			MetricName: fmt.Sprintf("anode.threesig.%s.lower", d.MetricName),
 			Timestamp:  d.Timestamp,
 			Value:      t.stats.Mean() - 3*stddev,
+			IsAnamoly:  false,
 		}
 	}
 }

--- a/data/data.go
+++ b/data/data.go
@@ -4,4 +4,5 @@ type Datapoint struct {
 	MetricName string
 	Timestamp  int64
 	Value      float64
+	IsAnomaly  bool
 }


### PR DESCRIPTION
I added a `bool` field to the `data.Datapoint` struct that will say "yes, I am an anomaly".

This helps applications parse the output channel without creating a second channel that could potentially block if not properly/diligently read from. It also avoids a less-than-ideal `strings.HasSuffix("anomalous")` check.

I'm open to discussing other methods, but this seemed the easiest.
